### PR TITLE
Update ruff configuration

### DIFF
--- a/.github/workflows/test-endpoint.yml
+++ b/.github/workflows/test-endpoint.yml
@@ -63,9 +63,9 @@ jobs:
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff --format=github --select=E9,F63,F7,F82 .
+          ruff check --output-format=github --select=E9,F63,F7,F82 .
           # default set of ruff rules with GitHub Annotations
-          ruff --format=github .
+          ruff check --output-format=github .
       - name: Test with pytest
         env:
           PYTEST_ADDOPTS: "--color=yes"

--- a/.github/workflows/test-endpoint.yml
+++ b/.github/workflows/test-endpoint.yml
@@ -63,9 +63,9 @@ jobs:
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff --format=github --select=E9,F63,F7,F82 --line-length 120 --target-version=py311 .
+          ruff --format=github --select=E9,F63,F7,F82 .
           # default set of ruff rules with GitHub Annotations
-          ruff --format=github --line-length 120 --target-version=py311 .
+          ruff --format=github .
       - name: Test with pytest
         env:
           PYTEST_ADDOPTS: "--color=yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ py-modules = []
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
 [project]
 name = "mittaridatapumppu-endpoint"
 description = ""


### PR DESCRIPTION
I noticed that ruff complained about the used command option being deprecated, so I updated it.
Then I also defined the target-version and line-length in pyproject.toml, so they will apply when running ruff check locally as well.