### PR TITLE
add extracted device id to kafka raw data topic

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,8 @@ async def api_v2(request: Request, endpoint: dict) -> Response:
     )
     response_message = str(response_message)
     print("REMOVE ME", auth_ok, device_id, topic_name, response_message, status_code)
+    # add extracted device id to request data before pushing to kafka raw data topic
+    request_data["device_id"] = device_id
     # We assume device data is valid here
     logging.debug(pprint.pformat(request_data))
     if auth_ok and topic_name:

--- a/tests/test_api2.py
+++ b/tests/test_api2.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from datetime import datetime, timedelta, timezone
-import json
 import httpx
 
 logging.basicConfig(level=logging.INFO)
@@ -94,7 +93,7 @@ def test_digita_endppoint_authenticated_access():
     # Replace Time with ~current time
     ts = (datetime.now(timezone.utc) - timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S.%f%z")
     payload["DevEUI_uplink"]["Time"] = ts
-    resp = httpx.post(url, headers=headers, params=params, data=json.dumps(payload))
+    resp = httpx.post(url, headers=headers, params=params, data=payload)
     logging.info(resp.text)
     assert resp.status_code in [200, 201, 202], "message forwarded"
     params["x-api-key"] = "wrong"

--- a/tests/test_api2.py
+++ b/tests/test_api2.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime, timedelta, timezone
-
+import json
 import httpx
 
 logging.basicConfig(level=logging.INFO)
@@ -94,7 +94,7 @@ def test_digita_endppoint_authenticated_access():
     # Replace Time with ~current time
     ts = (datetime.now(timezone.utc) - timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S.%f%z")
     payload["DevEUI_uplink"]["Time"] = ts
-    resp = httpx.post(url, headers=headers, params=params, data=payload)
+    resp = httpx.post(url, headers=headers, params=params, data=json.dumps(payload))
     logging.info(resp.text)
     assert resp.status_code in [200, 201, 202], "message forwarded"
     params["x-api-key"] = "wrong"


### PR DESCRIPTION
added already extracted device id to kafka raw data. this avoids extracting again from request params/body on parser.app